### PR TITLE
fixing inverted y axis

### DIFF
--- a/source/screen.py
+++ b/source/screen.py
@@ -30,7 +30,7 @@ class Screen():
                             cs        = Pin(pin_defs.throwaway, Pin.OUT), ## not used, grounded on board
                             dc        = self.dc,
                             backlight = Pin(pin_defs.throwaway, Pin.OUT), ## not used, always on
-                            rotation  = 0)
+                            rotation  = 6)
         self.tft.init()   
         self.tft.fill(gc9a01.color565(10,15,10))
 


### PR DESCRIPTION
It seems like vetorscope.py imports screen.py where all other programs are importing screennorm.py. Both screennorm and screen are initialising the GC9A01 display. There is a rotation flag (6) that allows for a mirrored rotation by 180 degrees [see library](https://github.com/russhughes/gc9a01_mpy/blob/3d6441ea4e596905254ba889c43b6e40c9af32f4/sphinx/gc9a01.rst#L33)

So since only screen.py is only used by vectorscope.py, I'd suggest using this rotation flag here.