### PR TITLE
Improve dynamic text

### DIFF
--- a/source/menu.py
+++ b/source/menu.py
@@ -16,6 +16,8 @@ BACK=-1
 EXIT=1
 CONT=0
 
+TEXT, CMD, ARG = range(3)
+
 SUBMENU=[]
 
 def m_back(arg):
@@ -165,11 +167,17 @@ class Menu:
                  xfg=self.fg
                  xbg=self.bg
              
+             text = self.current[self.dispmenu + i][TEXT]
+
+             if callable(text):
+                 text = text()
+
              # screen.tft.fill_rect(24,40*(i+1),195,40,xbg)
              if self.font==None:
-                 screen.text(24,40*(i+1),self.current[self.dispmenu+i][0],xfg,xbg)
+                 screen.text(24, 40 * (i + 1), text, xfg, xbg)
              else:
-                 screen.text_font(self.font,24,40*(i+1)+20,self.current[self.dispmenu+i][0],xfg,self.scale)
+                 screen.text_font(self.font, 24, 40 * (i + 1) + 20, text, xfg,
+                                  self.scale)
 
 
 

--- a/source/supercon_menu.py
+++ b/source/supercon_menu.py
@@ -19,12 +19,10 @@ def planets(arg):
     vectoros.launch_task('planets')  # launch
     return EXIT
 
-def menu_custom(the_menu):
-    if the_menu.level==1:
-        if machine.Pin(22).value():
-            the_menu.current[2]=[" Sound Off",toggle_sound,0]
-        else:
-            the_menu.current[2]=[" Sound On",toggle_sound,1]
+
+def dynamic_sound_text():
+    return " Sound Off" if machine.Pin(22).value() else " Sound On"
+
 
 def toggle_sound(arg):
     ## toggle sound here
@@ -77,16 +75,20 @@ async def vos_main():
         with Menu(clear_after=True,fg_color=colors.PHOSPHOR_DARK,bg_color=colors.PHOSPHOR_BG,
                   cursor_bg=colors.PHOSPHOR_BG, cursor_fg=colors.PHOSPHOR_BRIGHT) as amenu:  
             ## name in menu, command to run, return value?
-            submenu=[["  Planets", planets, 0],["  Sketch",runsketch,0],["  Back",m_exit,None]]
-            mainmenu=[[" Lissajous", run_lissajous,None],
-                      [" Demos", SUBMENU, submenu] ,
-                      [" Sound", toggle_sound, None],
-                      [" Reboot",reboot,False],
-                      ]
+            submenu = [
+                ["  Planets", planets, 0],
+                ["  Sketch", runsketch, 0],
+                ["  Back", m_exit, None],
+            ]
+            mainmenu = [
+                [" Lissajous", run_lissajous, None],
+                [" Demos", SUBMENU, submenu],
+                [dynamic_sound_text, toggle_sound, None],
+                [" Reboot", reboot, False],
+            ]
 
-# comment next line for default font
+            # comment next line for default font
             amenu.set_font("*")   # set default vector font
-            amenu.set_callback(menu_custom)
             await amenu.do_menu(mainmenu)
         vos_debug.debug_print(vos_debug.DEBUG_LEVEL_INFO,f"Menu waiting {vos_state.show_menu}")
         while vos_state.show_menu==False:   # wait until we have to be seen again


### PR DESCRIPTION
Currently, if you want to add a menu item, you have to update the offset of the sound option in the `menu_custom` callback. This is complicated and confusing for newcomers. Instead, it's possible to make it so the 0th element of the menu entry is either text or a reference to a function. In the latter case, the function is called and the returned text is displayed. Like this, it's possible to define a simple function that only has to care about what text it should display, not about the (manually updated) index at which the text should be displayed.